### PR TITLE
Test cleanup, and add 'more system' test

### DIFF
--- a/roles/test_asa_config/tests/cli/more_system.yaml
+++ b/roles/test_asa_config/tests/cli/more_system.yaml
@@ -1,0 +1,33 @@
+---
+- debug: msg="START cli/more_system.yaml"
+
+- name: setup
+  asa_config:
+    lines:
+      - "clear configure tunnel-group 1.1.1.1"
+    provider: "{{ cli }}"
+
+- name: Setup tunnel-group
+  asa_config:
+    before: tunnel-group 1.1.1.1 type ipsec-l2l
+    parents: tunnel-group 1.1.1.1 type ipsec-l2l
+    lines:
+      - "ikev1 pre-shared-key abc123"
+    show_command: "more system:running-config"
+    provider: "{{ cli }}"
+
+- name: Test idempotency
+  asa_config:
+    before: tunnel-group 1.1.1.1 type ipsec-l2l
+    parents: tunnel-group 1.1.1.1 type ipsec-l2l
+    lines:
+      - "ikev1 pre-shared-key abc123"
+    show_command: "more system:running-config"
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- debug: msg="END cli/more_system.yaml"

--- a/roles/test_asa_config/tests/cli/sublevel.yaml
+++ b/roles/test_asa_config/tests/cli/sublevel.yaml
@@ -6,7 +6,6 @@
     lines:
       - 'no object-group network OG-ANSIBLE-SUBLEVEL'
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure sub level command
   asa_config:
@@ -37,6 +36,5 @@
     lines:
       - 'no object-group network OG-ANSIBLE-SUBLEVEL'
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/sublevel.yaml"

--- a/roles/test_asa_config/tests/cli/sublevel_block.yaml
+++ b/roles/test_asa_config/tests/cli/sublevel_block.yaml
@@ -2,12 +2,19 @@
 - debug: msg="START cli/sublevel_block.yaml"
 
 - name: setup
+  asa_command:
+    commands:
+      - show run object-group
+    provider: "{{ cli }}"
+  register: object_group
+
+- name: setup
   asa_config:
     lines:
       - no object-group network OG-ANSIBLE
-    after: ['exit']
+    match: none
     provider: "{{ cli }}"
-    force: yes
+  #when: "'object-group network OG-ANSIBLE\n' in {{ object_group.stdout }}"
 
 - name: configure sub level command using block replace
   asa_config:
@@ -52,7 +59,6 @@
   asa_config:
     lines:
       - no object-group network OG-ANSIBLE
-    force: yes
     provider: "{{ cli }}"
 
 - debug: msg="END cli/sublevel_block.yaml"

--- a/roles/test_asa_config/tests/cli/sublevel_exact.yaml
+++ b/roles/test_asa_config/tests/cli/sublevel_exact.yaml
@@ -13,7 +13,6 @@
     before: ['no object-group network OG-ANSIBLE-EXACT']
     after: ['exit']
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure sub level command using exact match
   asa_config:
@@ -61,6 +60,5 @@
     lines:
       - no object-group network OG-ANSIBLE-EXACT
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/sublevel_exact.yaml"

--- a/roles/test_asa_config/tests/cli/sublevel_strict.yaml
+++ b/roles/test_asa_config/tests/cli/sublevel_strict.yaml
@@ -13,7 +13,6 @@
     before: ['no object-group network OG-ANSIBLE-STRICT']
     after: ['exit']
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure sub level command using strict match
   asa_config:
@@ -58,6 +57,5 @@
     lines:
       - no object-group network OG-ANSIBLE-STRICT
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/sublevel_strict.yaml"

--- a/roles/test_asa_config/tests/cli/toplevel.yaml
+++ b/roles/test_asa_config/tests/cli/toplevel.yaml
@@ -5,7 +5,6 @@
   asa_config:
     lines: ['hostname firewall']
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure top level command
   asa_config:
@@ -32,6 +31,5 @@
   asa_config:
     lines: ['hostname {{ inventory_hostname }}']
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/toplevel.yaml"

--- a/roles/test_asa_config/tests/cli/toplevel_after.yaml
+++ b/roles/test_asa_config/tests/cli/toplevel_after.yaml
@@ -7,7 +7,6 @@
       - "snmp-server contact ansible"
       - "hostname firewall"
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure top level command with before
   asa_config:
@@ -39,6 +38,5 @@
       - "no snmp-server contact"
       - "hostname {{ inventory_hostname }}"
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/toplevel_after.yaml"

--- a/roles/test_asa_config/tests/cli/toplevel_before.yaml
+++ b/roles/test_asa_config/tests/cli/toplevel_before.yaml
@@ -7,7 +7,6 @@
       - "snmp-server contact ansible"
       - "hostname firewall"
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure top level command with before
   asa_config:
@@ -39,6 +38,5 @@
       - "no snmp-server contact"
       - "hostname {{ inventory_hostname }}"
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/toplevel_before.yaml"

--- a/roles/test_asa_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/roles/test_asa_config/tests/cli/toplevel_nonidempotent.yaml
@@ -5,7 +5,6 @@
   asa_config:
     lines: ['hostname firewall']
     provider: "{{ cli }}"
-    force: yes
 
 - name: configure top level command
   asa_config:
@@ -34,6 +33,5 @@
   asa_config:
     lines: ['hostname {{ inventory_hostname }}']
     provider: "{{ cli }}"
-    force: yes
 
 - debug: msg="END cli/toplevel_nonidempotent.yaml"

--- a/roles/test_asa_template/tests/cli/backup.yaml
+++ b/roles/test_asa_template/tests/cli/backup.yaml
@@ -5,7 +5,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    force: yes
     provider: "{{ cli }}"
   ignore_errors: yes
 
@@ -49,7 +48,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    force: yes
     provider: "{{ cli }}"
 
 - debug: msg="END cli/backup.yaml"

--- a/roles/test_asa_template/tests/cli/basic.yaml
+++ b/roles/test_asa_template/tests/cli/basic.yaml
@@ -5,7 +5,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    force: yes
     provider: "{{ cli }}"
   ignore_errors: yes
 
@@ -35,7 +34,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    force: yes
     provider: "{{ cli }}"
 
 - debug: msg="END cli/basic.yaml"

--- a/roles/test_asa_template/tests/cli/defaults.yaml
+++ b/roles/test_asa_template/tests/cli/defaults.yaml
@@ -5,7 +5,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    force: yes
     provider: "{{ cli }}"
   ignore_errors: yes
 
@@ -41,7 +40,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    force: yes
     provider: "{{ cli }}"
 
 - debug: msg="END cli/defaults.yaml"

--- a/roles/test_asa_template/tests/cli/force.yaml
+++ b/roles/test_asa_template/tests/cli/force.yaml
@@ -5,7 +5,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    force: yes
     provider: "{{ cli }}"
   ignore_errors: yes
 
@@ -37,7 +36,6 @@
   asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    force: yes
     provider: "{{ cli }}"
 
 - debug: msg="END cli/force.yaml"


### PR DESCRIPTION
Clean up ASA tests, mostly to remove the force parameter.

I also added a test using the "more system:running config" option for showing config. Currently this test fails due to a bug.

`TASK [test_asa_config : Setup tunnel-group] ************************************
fatal: [ns2903-asa-02]: FAILED! => {"changed": false, "commands": ["configure terminal", "tunnel-group 1.1.1.1 type ipsec-l2l", "tunnel-group 1.1.1.1 type ipsec-l2l", "ikev1 pre-shared-key abc123", "end"], "failed": true, "msg": "matched error in response: tunnel-group 1.1.1.1 type ipsec-l2l\r\n                                            ^\r\nERROR: % Invalid input detected at '^' marker.\r\n\rns2903-asa-02(config)# "}`

This is the task:

`````` yaml
- name: Setup tunnel-group
  asa_config:
    before: tunnel-group 1.1.1.1 type ipsec-l2l
    parents: tunnel-group 1.1.1.1 type ipsec-l2l
    lines:
      - "ikev1 pre-shared-key abc123"
    show_command: "more system:running-config"
    provider: "{{ cli }}"```
``````
