### PR TITLE
asa_config: cleanup test for 'more system:running'

### DIFF
--- a/roles/test_asa_config/tests/cli/more_system.yaml
+++ b/roles/test_asa_config/tests/cli/more_system.yaml
@@ -7,10 +7,17 @@
       - "clear configure tunnel-group 1.1.1.1"
     provider: "{{ cli }}"
 
-- name: Setup tunnel-group
+
+- name: Prepare tunnel-group
   asa_config:
     before: tunnel-group 1.1.1.1 type ipsec-l2l
-    parents: tunnel-group 1.1.1.1 type ipsec-l2l
+    lines:
+      - "tunnel-group 1.1.1.1 ipsec-attributes"
+    provider: "{{ cli }}"
+
+- name: Setup tunnel-group
+  asa_config:
+    parents: tunnel-group 1.1.1.1 ipsec-attributes
     lines:
       - "ikev1 pre-shared-key abc123"
     show_command: "more system:running-config"
@@ -18,8 +25,7 @@
 
 - name: Test idempotency
   asa_config:
-    before: tunnel-group 1.1.1.1 type ipsec-l2l
-    parents: tunnel-group 1.1.1.1 type ipsec-l2l
+    parents: tunnel-group 1.1.1.1 ipsec-attributes
     lines:
       - "ikev1 pre-shared-key abc123"
     show_command: "more system:running-config"
@@ -29,5 +35,12 @@
 - assert:
     that:
       - "result.changed == false"
+
+- name: teardown
+  asa_config:
+    lines:
+      - "clear configure tunnel-group 1.1.1.1"
+    provider: "{{ cli }}"
+
 
 - debug: msg="END cli/more_system.yaml"


### PR DESCRIPTION
After the bug with the appended `end` statements has been fixed I did a cleanup of the test using `more system:running`.

The test currently fails due to an issue after the refactoring of [asa.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/asa.py)

``` Python
add_argument('show_command', dict(default='show running-config', choices=['show running-config', 'more system:running-config']))
add_argument('context', dict(required=False))

    def get_config(self, include_defaults=False, **kwargs):
        cmd = 'show running-config'
        if include_defaults:
            cmd += ' all'
        return self.run_commands(cmd)[0]
```

Basically the "show run" in the ASA masks passwords, you can use "more system:running-config" to get around this. The parameter is available in the modules, but the function to get_config doesn't use that parameter.

This test ensures that it's possible to use the "more system:running-config" (which currently has been removed).
