### PR TITLE
Extend eos_config tests to defend 2.2 features

### DIFF
--- a/roles/test_eos_config/templates/basic/config.j2
+++ b/roles/test_eos_config/templates/basic/config.j2
@@ -1,0 +1,4 @@
+interface Ethernet5
+   description this is a test
+   shutdown
+

--- a/roles/test_eos_config/templates/config.js
+++ b/roles/test_eos_config/templates/config.js
@@ -1,0 +1,4 @@
+interface Ethernet5
+   description test description from ansible
+   shutdown
+

--- a/roles/test_eos_config/templates/defaults/config.j2
+++ b/roles/test_eos_config/templates/defaults/config.j2
@@ -1,0 +1,3 @@
+interface Ethernet5
+   description this is a test
+   no shutdown

--- a/roles/test_eos_config/templates/defaults/test.j2
+++ b/roles/test_eos_config/templates/defaults/test.j2
@@ -1,0 +1,4 @@
+interface Ethernet5
+   description this is a test
+   shutdown
+

--- a/roles/test_eos_config/tests/cli/backup.yaml
+++ b/roles/test_eos_config/tests/cli/backup.yaml
@@ -25,7 +25,7 @@
   with_items: backup_files.files
 
 - name: configure device with config
-  eos_template:
+  eos_config:
     src: basic/config.j2
     backup: yes
     provider: "{{ cli }}"

--- a/roles/test_eos_config/tests/cli/backup.yaml
+++ b/roles/test_eos_config/tests/cli/backup.yaml
@@ -1,0 +1,50 @@
+---
+- debug: msg="START cli/backup.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    force: yes
+    provider: "{{ cli }}"
+
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname }}_config*"
+  register: backup_files
+  delegate_to: localhost
+
+- name: delete backup files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: backup_files.files
+
+- name: configure device with config
+  eos_template:
+    src: basic/config.j2
+    backup: yes
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.updates is defined"
+
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname }}_config*"
+  register: backup_files
+  delegate_to: localhost
+
+- assert:
+    that:
+      - "backup_files.files is defined"
+
+- debug: msg="END cli/backup.yaml"

--- a/roles/test_eos_config/tests/cli/backup.yaml
+++ b/roles/test_eos_config/tests/cli/backup.yaml
@@ -34,7 +34,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "result.updates is defined"
+      - "result.updates is not defined"
 
 - name: collect any backup files
   find:

--- a/roles/test_eos_config/tests/cli/defaults.yaml
+++ b/roles/test_eos_config/tests/cli/defaults.yaml
@@ -1,0 +1,42 @@
+---
+- debug: msg="START cli/defaults.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Ethernet5
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure device with defaults included
+  eos_config:
+    src: defaults/config.j2
+    defaults: yes
+    provider: "{{ cli }}"
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.updates is not defined"
+
+- name: check device with defaults included
+  eos_config:
+    src: defaults/config.j2
+    defaults: yes
+    provider: "{{ cli }}"
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.updates is not defined"
+
+- debug: msg="END cli/defaults.yaml"

--- a/roles/test_eos_config/tests/cli/save.yaml
+++ b/roles/test_eos_config/tests/cli/save.yaml
@@ -32,9 +32,4 @@
     that:
       - "result.changed == true"
 
-
-- name: fail now
-  fail:
-    msg: WIP
-
 - debug: msg="END cli/save.yaml"

--- a/roles/test_eos_config/tests/cli/save.yaml
+++ b/roles/test_eos_config/tests/cli/save.yaml
@@ -1,0 +1,40 @@
+---
+- debug: msg="START cli/save.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    force: yes
+    provider: "{{ cli }}"
+
+
+- name: save config
+  eos_config:
+    save: true
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: save should always run
+  eos_config:
+    save: true
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+
+- name: fail now
+  fail:
+    msg: WIP
+
+- debug: msg="END cli/save.yaml"

--- a/roles/test_eos_config/tests/cli/src_basic.yaml
+++ b/roles/test_eos_config/tests/cli/src_basic.yaml
@@ -1,0 +1,40 @@
+---
+- debug: msg="START cli/src_basic.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure device with config
+  eos_config:
+    src: basic/config.j2
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+# FIXME Currently failing
+# https://github.com/ansible/ansible-modules-core/issues/4807
+#      - "result.updates is defined"
+
+- name: check device with config
+  eos_config:
+    src: basic/config.j2
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+# FIXME Currently failing
+# https://github.com/ansible/ansible-modules-core/issues/4807
+#      - "result.updates is defined"
+
+- debug: msg="END cli/src_basic.yaml"

--- a/roles/test_eos_config/tests/cli/src_basic.yaml
+++ b/roles/test_eos_config/tests/cli/src_basic.yaml
@@ -20,9 +20,8 @@
 - assert:
     that:
       - "result.changed == true"
-# FIXME Currently failing
 # https://github.com/ansible/ansible-modules-core/issues/4807
-#      - "result.updates is defined"
+      - "result.updates is not defined"
 
 - name: check device with config
   eos_config:
@@ -33,8 +32,7 @@
 - assert:
     that:
       - "result.changed == false"
-# FIXME Currently failing
 # https://github.com/ansible/ansible-modules-core/issues/4807
-#      - "result.updates is defined"
+      - "result.updates is not defined"
 
 - debug: msg="END cli/src_basic.yaml"

--- a/roles/test_eos_config/tests/cli/src_invalid.yaml
+++ b/roles/test_eos_config/tests/cli/src_invalid.yaml
@@ -14,6 +14,6 @@
     that:
       - "result.changed == false"
       - "result.failed == true"
-      - "result.msg = 'path specified in src not found'"
+      - "result.msg == 'path specified in src not found'"
 
 - debug: msg="END cli/src_invalid.yaml"

--- a/roles/test_eos_config/tests/cli/src_invalid.yaml
+++ b/roles/test_eos_config/tests/cli/src_invalid.yaml
@@ -1,0 +1,19 @@
+---
+- debug: msg="START cli/src_invalid.yaml"
+
+
+# Defend https://github.com/ansible/ansible-modules-core/issues/4797
+- name: configure with invalid src
+  eos_config:
+    src: basic/foobar.j2
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.failed == true"
+      - "result.msg = 'path specified in src not found'"
+
+- debug: msg="END cli/src_invalid.yaml"

--- a/roles/test_eos_config/tests/cli/src_match_none.yaml
+++ b/roles/test_eos_config/tests/cli/src_match_none.yaml
@@ -21,9 +21,8 @@
 - assert:
     that:
       - "result.changed == true"
-# FIXME Currently failing
 # https://github.com/ansible/ansible-modules-core/issues/4807
-#      - "result.updates is defined"
+      - "result.updates is not defined"
 
 - name: check device with config
   eos_config:
@@ -35,8 +34,7 @@
 - assert:
     that:
       - "result.changed == true"
-# FIXME Currently failing
 # https://github.com/ansible/ansible-modules-core/issues/4807
-#      - "result.updates is defined"
+      - "result.updates is not defined"
 
 - debug: msg="END cli/src_match_none.yaml"

--- a/roles/test_eos_config/tests/cli/src_match_none.yaml
+++ b/roles/test_eos_config/tests/cli/src_match_none.yaml
@@ -1,0 +1,42 @@
+---
+- debug: msg="START cli/src_match_none.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure device with config
+  eos_config:
+    src: basic/config.j2
+    provider: "{{ cli }}"
+    match: none
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+# FIXME Currently failing
+# https://github.com/ansible/ansible-modules-core/issues/4807
+#      - "result.updates is defined"
+
+- name: check device with config
+  eos_config:
+    src: basic/config.j2
+    provider: "{{ cli }}"
+    match: none
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+# FIXME Currently failing
+# https://github.com/ansible/ansible-modules-core/issues/4807
+#      - "result.updates is defined"
+
+- debug: msg="END cli/src_match_none.yaml"

--- a/roles/test_eos_config/tests/cli/toplevel.yaml
+++ b/roles/test_eos_config/tests/cli/toplevel.yaml
@@ -34,6 +34,4 @@
     match: none
     provider: "{{ cli }}"
 
-
-
 - debug: msg="END cli/toplevel.yaml"

--- a/roles/test_eos_config/tests/eapi/backup.yaml
+++ b/roles/test_eos_config/tests/eapi/backup.yaml
@@ -25,7 +25,7 @@
   with_items: backup_files.files
 
 - name: configure device with config
-  eos_template:
+  eos_config:
     src: basic/config.j2
     backup: yes
     provider: "{{ eapi }}"

--- a/roles/test_eos_config/tests/eapi/backup.yaml
+++ b/roles/test_eos_config/tests/eapi/backup.yaml
@@ -34,7 +34,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "result.updates is defined"
+      - "result.updates is not defined"
 
 - name: collect any backup files
   find:

--- a/roles/test_eos_config/tests/eapi/backup.yaml
+++ b/roles/test_eos_config/tests/eapi/backup.yaml
@@ -1,0 +1,50 @@
+---
+- debug: msg="START eapi/backup.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    force: yes
+    provider: "{{ eapi }}"
+
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname }}_config*"
+  register: backup_files
+  delegate_to: localhost
+
+- name: delete backup files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: backup_files.files
+
+- name: configure device with config
+  eos_template:
+    src: basic/config.j2
+    backup: yes
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.updates is defined"
+
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname }}_config*"
+  register: backup_files
+  delegate_to: localhost
+
+- assert:
+    that:
+      - "backup_files.files is defined"
+
+- debug: msg="END eapi/backup.yaml"

--- a/roles/test_eos_config/tests/eapi/defaults.yaml
+++ b/roles/test_eos_config/tests/eapi/defaults.yaml
@@ -1,0 +1,42 @@
+---
+- debug: msg="START eapi/defaults.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Ethernet5
+    match: none
+    provider: "{{ eapi }}"
+
+- name: configure device with defaults included
+  eos_config:
+    src: defaults/config.j2
+    defaults: yes
+    provider: "{{ eapi }}"
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.updates is not defined"
+
+- name: check device with defaults included
+  eos_config:
+    src: defaults/config.j2
+    defaults: yes
+    provider: "{{ eapi }}"
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.updates is not defined"
+
+- debug: msg="END eapi/defaults.yaml"

--- a/roles/test_eos_config/tests/eapi/save.yaml
+++ b/roles/test_eos_config/tests/eapi/save.yaml
@@ -1,0 +1,35 @@
+---
+- debug: msg="START eapi/save.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    force: yes
+    provider: "{{ eapi }}"
+
+
+- name: save config
+  eos_config:
+    save: true
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: save should always run
+  eos_config:
+    save: true
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- debug: msg="END eapi/save.yaml"

--- a/roles/test_eos_config/tests/eapi/src_basic.yaml
+++ b/roles/test_eos_config/tests/eapi/src_basic.yaml
@@ -1,0 +1,38 @@
+---
+- debug: msg="START eapi/src_basic.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface Ethernet5
+    match: none
+    provider: "{{ eapi }}"
+
+- name: configure device with config
+  eos_config:
+    src: basic/config.j2
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+# https://github.com/ansible/ansible-modules-core/issues/4807
+      - "result.updates is not defined"
+
+- name: check device with config
+  eos_config:
+    src: basic/config.j2
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+# https://github.com/ansible/ansible-modules-core/issues/4807
+      - "result.updates is not defined"
+
+- debug: msg="END eapi/src_basic.yaml"

--- a/roles/test_eos_config/tests/eapi/src_invalid.yaml
+++ b/roles/test_eos_config/tests/eapi/src_invalid.yaml
@@ -1,0 +1,19 @@
+---
+- debug: msg="START eapi/src_invalid.yaml"
+
+
+# Defend https://github.com/ansible/ansible-modules-core/issues/4797
+- name: configure with invalid src
+  eos_config:
+    src: basic/foobar.j2
+    provider: "{{ eapi }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.failed == true"
+      - "result.msg == 'path specified in src not found'"
+
+- debug: msg="END eapi/src_invalid.yaml"

--- a/roles/test_eos_config/tests/eapi/src_match_none.yaml
+++ b/roles/test_eos_config/tests/eapi/src_match_none.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START cli/src_match_none.yaml"
+- debug: msg="START eapi/src_match_none.yaml"
 
 - name: setup
   eos_config:
@@ -9,12 +9,12 @@
     parents:
       - interface Ethernet5
     match: none
-    provider: "{{ cli }}"
+    provider: "{{ eapi }}"
 
 - name: configure device with config
   eos_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
+    provider: "{{ eapi }}"
     match: none
   register: result
 
@@ -27,7 +27,7 @@
 - name: check device with config
   eos_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
+    provider: "{{ eapi }}"
     match: none
   register: result
 
@@ -38,4 +38,4 @@
       - "result.changed == false"
       - "result.updates is not defined"
 
-- debug: msg="END cli/src_match_none.yaml"
+- debug: msg="END eapi/src_match_none.yaml"

--- a/roles/test_eos_config/tests/eapi/toplevel.yaml
+++ b/roles/test_eos_config/tests/eapi/toplevel.yaml
@@ -28,7 +28,7 @@
     that:
       - "result.changed == false"
 
-- name: setup
+- name: teardown
   eos_config:
     lines: hostname {{ inventory_hostname }}
     match: none

--- a/roles/test_eos_config/tests/eapi/toplevel_before.yaml
+++ b/roles/test_eos_config/tests/eapi/toplevel_before.yaml
@@ -33,7 +33,7 @@
     that:
       - "result.changed == false"
 
-- name: setup
+- name: teardown
   eos_config:
     lines:
       - no snmp-server contact ansible


### PR DESCRIPTION
Added the following
- eos_config `src:` based off existing eos_template's tests
  - Defend against src file not existing https://github.com/ansible/ansible-modules-core/issues/4797
  - Ensure `result.updates` doesn't get set
- eos_config `defaults:` based off existing eos_template's tests
- eos_config `backup:` based off existing eos_template's tests
- eos_config `save:` - Save twice, ensure it always reports changed,
- Minor tidy up of formatting
