### PR TITLE
fixes test_eos_config role checking backups

### DIFF
--- a/roles/test_eos_config/tests/cli/backup.yaml
+++ b/roles/test_eos_config/tests/cli/backup.yaml
@@ -18,11 +18,14 @@
   register: backup_files
   delegate_to: localhost
 
+- debug: var=backup_files
+
 - name: delete backup files
   file:
     path: "{{ item.path }}"
     state: absent
-  with_items: "{{backup_files.files|default([])}}"
+  with_items: backup_files.files
+  when: backup_files.files
 
 - name: configure device with config
   eos_config:

--- a/roles/test_eos_config/tests/eapi/backup.yaml
+++ b/roles/test_eos_config/tests/eapi/backup.yaml
@@ -22,7 +22,8 @@
   file:
     path: "{{ item.path }}"
     state: absent
-  with_items: "{{backup_files.files|default([])}}"
+  with_items: backup_files.files
+  when: backup_files.files
 
 - name: configure device with config
   eos_config:


### PR DESCRIPTION
This fixes an issue with the backup test case where the generated
variable wasn't checked if it was defined before it was attempted to be
accessed by the playbook
