### PR TITLE
Check for updated invalid subset message

### DIFF
--- a/roles/test_eos_facts/tests/cli/invalid_subset.yaml
+++ b/roles/test_eos_facts/tests/cli/invalid_subset.yaml
@@ -18,7 +18,7 @@
       # It's a failure
       - "result.failed == true"
       # Sensible Failure message
-      #- "result.msg == 'Bad subset'"
+      - "'Subset must be one of' in result.msg"
 
 ###############
 # FIXME Future

--- a/roles/test_eos_facts/tests/eapi/invalid_subset.yaml
+++ b/roles/test_eos_facts/tests/eapi/invalid_subset.yaml
@@ -18,7 +18,7 @@
       # It's a failure
       - "result.failed == true"
       # Sensible Failure message
-      #- "result.msg == 'Bad subset'"
+      - "'Subset must be one of' in result.msg"
 
 ###############
 # FIXME Future


### PR DESCRIPTION
The error message got updated so check for that.
We check for the error message to ensure we aren't failing and throwing a backtrace
