### PR TITLE
[EOS] Add eos_config test cases for banner login

### DIFF
--- a/roles/test_eos_config/templates/basic/banner_login.j2
+++ b/roles/test_eos_config/templates/basic/banner_login.j2
@@ -1,0 +1,6 @@
+banner login
+This is my banner
+
+That ^ is an empty line
+    This is an indented line
+EOF

--- a/roles/test_eos_config/tests/cli/banner_login.yaml
+++ b/roles/test_eos_config/tests/cli/banner_login.yaml
@@ -1,0 +1,33 @@
+---
+- debug: msg="START cli/banner_login.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no banner login
+    provider: "{{ cli }}"
+
+- name: configure device with login banner
+  eos_config:
+    src: basic/banner_login.j2
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.updates is not defined"
+
+- name: check device with login banner
+  eos_config:
+    src: basic/banner_login.j2
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+# https://github.com/ansible/ansible-modules-core/issues/4807
+      - "result.updates is not defined"
+
+- debug: msg="END cli/banner_login.yaml"

--- a/roles/test_eos_config/tests/eapi/banner_login.yaml
+++ b/roles/test_eos_config/tests/eapi/banner_login.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START cli/banner_login.yaml"
+- debug: msg="START eapi/banner_login.yaml"
 
 - name: setup
   eos_config:

--- a/roles/test_eos_config/tests/eapi/banner_login.yaml
+++ b/roles/test_eos_config/tests/eapi/banner_login.yaml
@@ -1,0 +1,33 @@
+---
+- debug: msg="START cli/banner_login.yaml"
+
+- name: setup
+  eos_config:
+    commands:
+      - no banner login
+    provider: "{{ eapi }}"
+
+- name: configure device with login banner
+  eos_config:
+    src: basic/banner_login.j2
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.updates is not defined"
+
+- name: check device with login banner
+  eos_config:
+    src: basic/banner_login.j2
+    provider: "{{ eapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+# https://github.com/ansible/ansible-modules-core/issues/4807
+      - "result.updates is not defined"
+
+- debug: msg="END eapi/banner_login.yaml"


### PR DESCRIPTION
This case fails of CLI and EAPI and exposes some other issues.  If you notice the eapi test case:

Jinja template:

```
banner login
This is my banner

That ^ is an empty line
    This is an indented line
EOF
```

There are indentations as well as blank lines that aren't preserved in the request:

```
TASK [test_eos_config : configure device with login banner] ********************
fatal: [dc1-spine1]: FAILED! => {"changed": false, "code": 1002, "commands": ["enable", "configure session ansible_1476367452", "banner login", "This is my banner", "That ^ is an empty line", "This is an indented line", "EOF", "end"], "data": [{}, {}, {}, {"errors": ["Invalid input (at token 0: 'This')"]}], "failed": true, "msg": "CLI command 4 of 8 'This is my banner' failed: invalid command"}
```

I'll raise an issue for this in the core repo.
